### PR TITLE
CSS-294: Symbol conversion script now acts on new image_index property

### DIFF
--- a/ppsymbols.py
+++ b/ppsymbols.py
@@ -69,7 +69,7 @@ def edit_symbol_node(node, filename):
     node.append(pv_element)
 
     rule_element = node.find('.//rule')
-    rule_element.set('prop_id', 'pv_value')
+    rule_element.set('prop_id', 'image_index')
     rule_element.set('out_exp', 'true')
 
     file_element = et.Element('image_file')


### PR DESCRIPTION
Allows rules to update the symbol widget, and have a PV associated with it, while not causing race conditions. See https://github.com/dls-controls/org.csstudio.dls.product/pull/150.
