### PR TITLE
Fix remaining unittest failures

### DIFF
--- a/convert/colourtweak.py
+++ b/convert/colourtweak.py
@@ -147,13 +147,13 @@ def change_colours(widget):
     typeId = widget.get("typeId")
     # Parent lookup for colours
     colour_prop = {c:p.tag for p in widget.iter() for c in p}
-    # Look for colour elements two elements below.
+    # Look for colour elements two (or more) elements below.
     # <foreground_color>
     #   <color blue="32" green="64" name="Related Display: FG" red="128" />
     # </foreground_color>
     # Other colour elements may be inside child widgets (e.g. within grouping
     # containers) and need to be handled in those widgets.
-    for colour in widget.findall("./*/color"):
+    for colour in widget.findall("./*//color"):
         # Map colours
         name = colour.get("name")
         if name is None:

--- a/convert/colourtweak.py
+++ b/convert/colourtweak.py
@@ -5,7 +5,7 @@ import logging as log
 
 import utils
 
-COLOR_DEF = 'res/colourtweak.def'
+COLOR_DEF_FILE = 'res/colourtweak.def'
 
 DISPLAY = "org.csstudio.opibuilder.Display"
 ACTIONBUTTON = "org.csstudio.opibuilder.widgets.ActionButton"
@@ -22,17 +22,26 @@ CHOICEBUTTON = "org.csstudio.opibuilder.widgets.choiceButton"
 BYTEMONITOR = "org.csstudio.opibuilder.widgets.bytemonitor"
 BOOLBUTTON = "org.csstudio.opibuilder.widgets.BoolButton"
 
-# colour_dict["Red"] = (255, 0, 0)
+# dictionary of KEY:(r,g,b) tuple
 colour_dict = {}
-with open(COLOR_DEF) as f:
-    for line in f:
-        # get rid of comments
-        split = line.strip().split("#")
-        if split[0]:
-            # name = r, g, b
-            name, rgb = split[0].split("=")
-            r, g, b = rgb.split(",")
-            colour_dict[name.strip()] = (r.strip(), g.strip(), b.strip())
+
+
+def init(filepath=COLOR_DEF_FILE):
+    """ Parse a colour definitions file containing "key = r, g, b" lines
+    Args:
+        filepath: file to load
+
+    """
+    with open(filepath) as f:
+        for line in f:
+            # get rid of comments
+            split = line.strip().split("#")
+            if split[0]:
+                # name = r, g, b
+                name, rgb = split[0].split("=")
+                r, g, b = rgb.split(",")
+                colour_dict[name.strip()] = (r.strip(), g.strip(), b.strip())
+
 
 def set_colour(el, name):
     # set colour attributes to be according to the named colour
@@ -43,7 +52,7 @@ def set_colour(el, name):
     el.set("name", name)
 
 # Map of colours with no widget specific changes
-colour_map = {
+COLOUR_MAP = {
     "Disconn/Invalid": "White",
     "Top Shadow": "Grey 90%",
     "grey-2": "Grey 90%",
@@ -128,6 +137,7 @@ colour_map = {
     "Disconnected": "Disconnected",
 }
 
+
 def change_colours(widget):
     textControls = [ACTIONBUTTON, TEXTINPUT, MENUBUTTON, CHOICEBUTTON, BOOLBUTTON]
     textMonitors = [TEXTUPDATE]
@@ -189,11 +199,12 @@ def change_colours(widget):
         elif name == "Exit/Quit/Kill" and typeId in [ACTIONBUTTON] and prop == "foreground_color":
             set_colour(colour, "Exit: FG")
         # If we have a static map, then just use that
-        elif name in colour_map:
-            set_colour(colour, colour_map[name])
+        elif name in COLOUR_MAP:
+            set_colour(colour, COLOUR_MAP[name])
         else:
             # remove name
             colour.attrib.pop("name")
+
 
 def parse(filepath):
     try:

--- a/convert/colourtweak.py
+++ b/convert/colourtweak.py
@@ -147,13 +147,13 @@ def change_colours(widget):
     typeId = widget.get("typeId")
     # Parent lookup for colours
     colour_prop = {c:p.tag for p in widget.iter() for c in p}
-    # Look for colour elements two (or more) elements below.
+    # Look for colour elements two elements below.
     # <foreground_color>
     #   <color blue="32" green="64" name="Related Display: FG" red="128" />
     # </foreground_color>
     # Other colour elements may be inside child widgets (e.g. within grouping
     # containers) and need to be handled in those widgets.
-    for colour in widget.findall("./*//color"):
+    for colour in widget.findall("./*/color"):
         # Map colours
         name = colour.get("name")
         if name is None:

--- a/convert/module.py
+++ b/convert/module.py
@@ -29,6 +29,9 @@ class Module(object):
             cfg_dict: general config info -- extra deps, edl and opi dirs
             mirror_root: root of target filesystem
         """
+        # force colour tweak to parse the lookup table
+        colourtweak.init()
+
         self.coords = coords
         self.edl_dir = module_cfg.edl_dir
         self.opi_dir = module_cfg.opi_dir

--- a/test/test_colourtweak.py
+++ b/test/test_colourtweak.py
@@ -1,7 +1,7 @@
 #!/bin/env dls-python
 import sys, os
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
-from convert.colourtweak import change_colours
+from convert import colourtweak
 
 import unittest
 import xml.etree.ElementTree as ET
@@ -755,6 +755,11 @@ MISC_COLOURS_TWK = """<widget typeId="org.csstudio.opibuilder.widgets.Unknown" v
 
 
 class ColourChangeTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        colourtweak.init(filepath=os.path.join('..', colourtweak.COLOR_DEF_FILE))
+
     def assertStringsEqual(self, first, second, msg=None):
         """Assert that two multi-line strings are equal.
         If they aren't, show a nice diff.
@@ -771,7 +776,7 @@ class ColourChangeTest(unittest.TestCase):
 
     def do_colourtweak(self, text):
         root = ET.fromstring(text)
-        change_colours(root)
+        colourtweak.change_colours(root)
         return ET.tostring(root)
 
     def test_change_colours_label(self):

--- a/test/test_colourtweak.py
+++ b/test/test_colourtweak.py
@@ -467,7 +467,7 @@ TEXTUPDATE_TWK = """<widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" 
     <border_width>0</border_width>
     <border_style>1</border_style>
     <border_color>
-      <color blue="0" green="255" name="Green" red="0" />
+      <color blue="0" green="192" name="Mid Green" red="0" />
     </border_color>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <precision_from_pv>true</precision_from_pv>
@@ -685,7 +685,7 @@ MISC_COLOURS_TWK = """<widget typeId="org.csstudio.opibuilder.widgets.Unknown" v
       <color blue="64" green="64" name="Grey 25%" red="64" />
       <color blue="0" green="0" name="Black" red="0" />
       <color blue="0" green="255" name="Green" red="0" />
-      <color blue="0" green="255" name="Green" red="0" />
+      <color blue="0" green="192" name="Mid Green" red="0" />
       <color blue="0" green="192" name="Mid Green" red="0" />
       <color blue="0" green="192" name="Mid Green" red="0" />
       <color blue="0" green="128" name="Dark Green" red="0" />
@@ -785,6 +785,7 @@ class ColourChangeTest(unittest.TestCase):
     def test_anon_colour(self):
         self.assertStringsEqual(self.do_colourtweak(DISPLAY_ANON_COLOUR),
                                 DISPLAY_ANON_COLOUR_TWK)
+
     def test_change_colours_action_button(self):
         self.assertStringsEqual(self.do_colourtweak(ACTIONBUTTON), ACTIONBUTTON_TWK)
 


### PR DESCRIPTION
@willrogers I'm unsure about the findall() fix. The expression was initially `.//color` (all color tags) and changed to `./*/color` (all color tags one level down) to support grouping containings (SHA1: 5011511).
