### PR TITLE
Use pytest instead of nose to run unit tests.

### DIFF
--- a/jenkins_unittest.sh
+++ b/jenkins_unittest.sh
@@ -14,7 +14,7 @@ set +e
 mkdir logs
 
 # run tests
-nosetests --with-xunit --xunit-file=${WORKSPACE}/logs/nosetests.xml
+py.test --junitxml=${WORKSPACE}/logs/nosetests.xml
 
 # run pylint
 touch ${WORKSPACE}/__init__.py


### PR DESCRIPTION
@nickbattam @mfurseman 

The previous way of running didn't provide the pytest libraries I was using.