### PR TITLE
Remove version incrementing

### DIFF
--- a/checkouthead.py
+++ b/checkouthead.py
@@ -90,17 +90,13 @@ def checkout_coords(coords, cfg, include_deps=True, extra_deps=None, force=False
                             mcoords.area, mcoords.module, mcoords.version)
                 continue
 
-            new_version = css_utils.increment_version(mcoords.version)
-            log.info('Updated version %s/%s: %s', mcoords.area, mcoords.module, new_version)
-            new_coords = coordinates.update_version(mcoords, new_version)
-
-            new_path = coordinates.as_path(new_coords)
+            new_path = coordinates.as_path(mcoords)
             checkout_path = os.path.join(cfg.mirror_root, new_path[1:])
             if force and os.path.exists(checkout_path):
                 log.info('Removing %s before checking out', new_path)
                 shutil.rmtree(checkout_path)
 
-            checkout_module(new_coords.module, new_version, new_path,
+            checkout_module(mcoords.module, mcoords.version, new_path,
                             cfg.mirror_root, dep_cfg.is_git())
 
             if not opi_dir_is_empty(checkout_path, dep_cfg):
@@ -109,7 +105,7 @@ def checkout_coords(coords, cfg, include_deps=True, extra_deps=None, force=False
             extra_deps = coordinates.update_version_from_files(
                 dep_cfg.extra_deps, coords.root)
             config.create_module_ini_file(
-                new_coords, cfg.mirror_root, dep_cfg.opi_dir, extra_deps, force)
+                mcoords, cfg.mirror_root, dep_cfg.opi_dir, extra_deps, force)
 
         except ValueError:
             log.warn('Cannot handle coordinates %s', mcoords)

--- a/convert/module.py
+++ b/convert/module.py
@@ -20,7 +20,7 @@ OPI_EXTENSION = 'opi'
 class Module(object):
     """Object representing one IOC or support module."""
 
-    def __init__(self, coords, module_cfg, mirror_root, increment_version=True):
+    def __init__(self, coords, module_cfg, mirror_root):
         """
 
         Args:
@@ -46,16 +46,11 @@ class Module(object):
         # Used for locating an executable given only its name.
         self.path_dict = {}
 
-        if increment_version:
-            self.new_version = css_utils.increment_version(coords.version)
-        else:
-            self.new_version = coords.version
-
         prod_path = coordinates.as_path(coords, False)
         # prod_path[1:] strips leading / to allow creation of shadow
         # file system INSIDE a containing dir /.../dls_sw/prod/R3...
         self.conversion_root = os.path.join(mirror_root, prod_path[1:],
-                                            self.new_version)
+                                            coords.version)
 
         if not os.path.exists(self.conversion_root) and module_cfg.has_opi:
             err_msg = 'Module to be converted does not exist: {}'
@@ -69,10 +64,8 @@ class Module(object):
         Returns:
             dict {name: coords} for all module dependencies
         """
-        new_version = css_utils.increment_version(self.coords.version)
-        shadow_coord = coordinates.update_version(self.coords, new_version)
         dp = dependency.DependencyParser.from_coord(
-            shadow_coord, mirror_root=self.mirror_root, additional_depends=self.extra_deps)
+            self.coords, mirror_root=self.mirror_root, additional_depends=self.extra_deps)
         return dp.find_dependencies()
 
     def get_path_dirs(self):

--- a/convert_module.py
+++ b/convert_module.py
@@ -82,16 +82,15 @@ def convert_module(mod, gen_cfg, force):
     path_dirs = mod.get_path_dirs()
     for dep, dep_coords in dependencies.items():
         dep_cfg = gen_cfg.get_mod_cfg(dep)
-        new_version = css_utils.increment_version(dep_coords.version)
         dep_edl_path = os.path.join(gen_cfg.mirror_root,
                                     coordinates.as_path(dep_coords, False)[1:],
-                                    new_version,
+                                    dep_coords.version,
                                     dep_cfg.edl_dir)
         edl_dirs.append(dep_edl_path)
         for p in dep_cfg.path_dirs:
             dep_path = os.path.join(gen_cfg.mirror_root,
                                     coordinates.as_path(dep_coords, False)[1:],
-                                    new_version,
+                                    dep_coords.version,
                                     p)
             path_dirs.append(dep_path)
         mod_deps = dep_cfg.extra_deps
@@ -103,8 +102,7 @@ def convert_module(mod, gen_cfg, force):
     mod.path_dict = file_dict_to_path_dict(mod.file_dict, path_dirs)
     try:
         mod.convert(force)
-        new_version = css_utils.increment_version(mod.coords.version)
-        run_script.generate(mod.coords, new_version, gen_cfg.mirror_root,
+        run_script.generate(mod.coords, gen_cfg.mirror_root,
                             opi_dir=mod.opi_dir, converter_config=gen_cfg,
                             extra_depends=extra_depends)
     except ValueError as e:

--- a/ppsymbols.py
+++ b/ppsymbols.py
@@ -193,8 +193,7 @@ def start():
         depth = len(mod_name.split(os.path.sep))
         log.debug('The depth for module %s is %s', mod_name, depth)
         try:
-            mod = module.Module(coords, module_cfg, cfg.mirror_root,
-                                increment_version=False)
+            mod = module.Module(coords, module_cfg, cfg.mirror_root)
             edl_dirs = get_edl_dirs(mod, cfg)
 
             file_dict = paths.index_paths(edl_dirs, True)

--- a/test/test_module.py
+++ b/test/test_module.py
@@ -14,7 +14,6 @@ class ModuleTest(unittest.TestCase):
 
     def setUp(self):
         self.version = '5-3'
-        self.new_version = '5-4'
         self.module_path = '/dls_sw/prod/R3.14.12.3/ioc/LI/TI/'
         self.edl_path = 'MyApp/opi/edl'
         self.opi_path = 'MyApp/opi/opi'
@@ -51,14 +50,14 @@ class ModuleTest(unittest.TestCase):
     def test_get_edl_path(self):
         edl_path = os.path.join(self.mirror_root,
                                 self.module_path[1:],
-                                self.new_version,
+                                self.version,
                                 self.edl_path)
         self.assertEqual(os.path.normpath(edl_path), self.m.get_edl_path())
 
     def test_get_opi_path(self):
         opi_path = os.path.join(self.mirror_root,
                                 self.module_path[1:],
-                                self.new_version,
+                                self.version,
                                 self.opi_path)
         self.assertEqual(os.path.normpath(opi_path), self.m.get_opi_path())
 


### PR DESCRIPTION
When doing conversions into the shadow file system having the versions incremented made it clear that modules were depending on other newly created modules. Now we are converting production modules, it is a necessity that the GUI dependencies of these modules are converted and released into production before the child module can be converted. For this reason one will explicitly set the version requirements depending on the released modules, it is no longer appropriate to then increment this version when creating converted IOC's or the runcss.sh file.