### PR TITLE
Remove the parser object from deprecated function call

### DIFF
--- a/convert/configuration.py
+++ b/convert/configuration.py
@@ -48,7 +48,7 @@ class ModuleConfig(object):
                 elif key == 'extra_deps':
                     dependencies = config.split_value_list(value)
                     cfg_section[key] = config.parse_dependency_list(
-                        dependencies, config_parser)
+                        dependencies)
                 elif key == 'has_opi':
                     cfg_section[key] = config_parser.getboolean(name, key)
                 else:


### PR DESCRIPTION
Checkout head failed as it was using the parse_dependency_list call that has been modified in the latest dls_css_utils. Removing this argument means that that the area won't be taken from config_parser anymore. It can still be provided as part of the string that forms the only argument to parse_dependancy_list.